### PR TITLE
fix: mistakenly apply to `zh-yue` Wikipedia

### DIFF
--- a/Chinese (Simplified) first/Wikipedia (Chinese)/script.js
+++ b/Chinese (Simplified) first/Wikipedia (Chinese)/script.js
@@ -4,9 +4,7 @@
 // @description      Wikipedia 维基百科（中文）优先使用简体中文浏览
 // @version          1.3.1
 // @match            *zh.wikipedia.org/*
-// @match            *zh-yue.wikipedia.org/*
 // @match            *zh.m.wikipedia.org/*
-// @match            *zh-yue.m.wikipedia.org/*
 // @require          https://cdn.jsdelivr.net/gh/Roger-WIN/greasemonkey-user-scripts@bf3bbd28ab2ecfc677a3836ddc8a9c7943dca2d1/Chinese%20(Simplified)%20first/_common/language-first.js
 // @author           神齐 <RogerKung.WIN@outlook.com>
 // @license          MIT


### PR DESCRIPTION
Multiple Sinitic languages have their own Wikipedias: `zh`, `zh-yue`, `zh-classical`, `zh-min-nan`, `wuu`, `gan`, `hak`, and `cdo`. THEY ARE ALL COMPLETELY DIFFERENT LANGUAGES AND COMPLETELY DIFFERENT WIKIPEDIAS, CONTAINING COMPLETELY DIFFERENT CONTENT. ANY REDIRECTION BETWEEN THEM IS ROUGH AND SHOULD NEVER OCCUR. The lang codes, `zh-yue`, `zh-classical`, and `zh-min-nan`, are legacies, never indicating they were relevant to the `zh` Wikipedia, so did `wuu`, `gan`, `hak`, and `cdo`.

> **At the time of establishment, there was no ISO code for Cantonese.** Thus, zh-yue was used as the domain. However, some did not like the idea, as Yue is the Mandarin name of Cantonese. The native name is Yuet. Cantonese preserves [entering tone](https://en.wikipedia.org/wiki/Entering_tone) while Mandarin does not. Some suggested using Cantonese instead, but zh-yue was chosen as the final domain name.
> 
> **The ISO code for Cantonese is yue. Using the ISO code instead of current domain has been submitted as a proposal to Wikimedia**, but as of yet, no action has been taken to implement this change.
>
> https://en.wikipedia.org/wiki/Cantonese_Wikipedia

<hr>

Cantonese speakers who need to read Cantonese Wikipedia never need such a redirection. Non-Cantonese speakers hardly open links to Cantonese Wikipedia and hardly need such a redirection, not to mention the redirection is nearly useless since it is across two completely different Wikipedias.

Some of tons of annoying redirections:
https://zh-yue.wikipedia.org/wiki/杘 -> https://zh.wikipedia.org/zh-cn/粵語髒話#杘/𨳍 (less content)
https://zh-yue.wikipedia.org/wiki/Deoi6 -> https://zh.wikipedia.org/zh-cn/Deoi6 (even nothing)
https://zh-yue.wikipedia.org/wiki/南亞裔男被香港男警察跪頸後死亡案 -> https://zh.wikipedia.org/zh-cn/南亞裔男被香港男警察跪頸後死亡案 (even nothing)